### PR TITLE
Amb 2053 & AMB 2055 -   implement test update imms with duplicated identifier returns error and updating the e2e search imms testcases

### DIFF
--- a/backend/tests/test_update_imms.py
+++ b/backend/tests/test_update_imms.py
@@ -47,7 +47,6 @@ class TestUpdateImmunizations(unittest.TestCase):
 
     def test_update_imms_with_duplicated_identifier_returns_error(self):
         """Should return an IdentifierDuplication error"""
-        # TODO: BUG Implement this test
         lambda_event = {"pathParameters": {"id": "an-id"}}
         error_msg = {'statusCode': 422, 'headers': {'Content-Type': 'application/fhir+json'}, 'body': '{"resourceType": "OperationOutcome", "id": "5c132d8a-a928-4e0e-8792-0c6456e625c2", "meta": {"profile": ["https://simplifier.net/guide/UKCoreDevelopment2/ProfileUKCore-OperationOutcome"]}, "issue": [{"severity": "error", "code": "exception", "details": {"coding": [{"system": "https://fhir.nhs.uk/Codesystem/http-error-codes","code": "DUPLICATE"}]}, "diagnostics": "The provided identifier: id-id is duplicated"}]}'}
         self.controller.update_immunization.return_value = error_msg

--- a/backend/tests/test_update_imms.py
+++ b/backend/tests/test_update_imms.py
@@ -48,3 +48,13 @@ class TestUpdateImmunizations(unittest.TestCase):
     def test_update_imms_with_duplicated_identifier_returns_error(self):
         """Should return an IdentifierDuplication error"""
         # TODO: BUG Implement this test
+        lambda_event = {"pathParameters": {"id": "an-id"}}
+        error_msg = {'statusCode': 422, 'headers': {'Content-Type': 'application/fhir+json'}, 'body': '{"resourceType": "OperationOutcome", "id": "5c132d8a-a928-4e0e-8792-0c6456e625c2", "meta": {"profile": ["https://simplifier.net/guide/UKCoreDevelopment2/ProfileUKCore-OperationOutcome"]}, "issue": [{"severity": "error", "code": "exception", "details": {"coding": [{"system": "https://fhir.nhs.uk/Codesystem/http-error-codes","code": "DUPLICATE"}]}, "diagnostics": "The provided identifier: id-id is duplicated"}]}'}
+        self.controller.update_immunization.return_value = error_msg
+
+        act_res = update_imms(lambda_event, self.controller)
+       
+        # Then
+        self.controller.update_immunization.assert_called_once_with(lambda_event)
+        self.assertEqual(act_res["statusCode"], 422)
+        self.assertDictEqual(act_res, error_msg)

--- a/e2e/test_search_immunization.py
+++ b/e2e/test_search_immunization.py
@@ -24,7 +24,6 @@ class TestSearchImmunization(ImmunizationBaseTest):
         for imms_api in self.imms_apis:
             with self.subTest(imms_api):
                 # Given two patients each with one mmr
-                # TODO: BUG Check why mmr_p2 has flu vaccine type. Also see next test.
                 mmr_p1 = create_an_imms_obj(str(uuid.uuid4()), valid_nhs_number1, VaccineTypes.mmr)
                 mmr_p2 = create_an_imms_obj(str(uuid.uuid4()), valid_nhs_number2, VaccineTypes.mmr)
                 self.store_records(mmr_p1, mmr_p2)

--- a/e2e/test_search_immunization.py
+++ b/e2e/test_search_immunization.py
@@ -26,7 +26,7 @@ class TestSearchImmunization(ImmunizationBaseTest):
                 # Given two patients each with one mmr
                 # TODO: BUG Check why mmr_p2 has flu vaccine type. Also see next test.
                 mmr_p1 = create_an_imms_obj(str(uuid.uuid4()), valid_nhs_number1, VaccineTypes.mmr)
-                mmr_p2 = create_an_imms_obj(str(uuid.uuid4()), valid_nhs_number2, VaccineTypes.flu)
+                mmr_p2 = create_an_imms_obj(str(uuid.uuid4()), valid_nhs_number2, VaccineTypes.mmr)
                 self.store_records(mmr_p1, mmr_p2)
 
                 # When


### PR DESCRIPTION
## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

Add any other relevant notes or explanations here. **Remove this line if you have nothing to add.**


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
