### PR TITLE
Fix Dependabot exclusion in SonarCloud pipeline.

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   sonarcloud:
     name: SonarCloud
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
@@ -95,7 +95,7 @@ jobs:
             while IFS= read -r line; do
               echo "##[error]Test Failures: $line"
             done < failed_tests.txt
-            
+
             exit 1
           else
             echo "All tests passed."


### PR DESCRIPTION
## Summary
* Routine Change

Exclude Dependabot from attempting to run the SonarCloud pipeline (which will fail due to a missing `SONAR_TOKEN` secret - see https://github.com/dependabot/dependabot-core/issues/3253). It looks like we were already attempting to do this using a PR label check, but Dependabot now uses the `dependencies` label. This check should be more robust.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
