### PR TITLE
VED-153: Enable SonarCloud scanning for Dependabot PRs.

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   sonarcloud:
     name: SonarCloud
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
* Routine Change

I've added the `SONAR_TOKEN` as a Dependabot secret in GitHub, following the lead of the `patient-flags-api` repo, so this pipeline should now run successfully for Dependabot PRs.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
