### PR TITLE
VED-292-Single-Record-Exception-Mgt

### DIFF
--- a/delta_backend/src/delta.py
+++ b/delta_backend/src/delta.py
@@ -57,7 +57,7 @@ def send_message(record, queue_url=failure_queue_url):
         # Send the record to the queue
         get_sqs_client().send_message(QueueUrl=queue_url, MessageBody=json.dumps(message_body))
         logger.info("Record saved successfully to the DLQ")
-    except ClientError as e:
+    except Exception as e:
         logger.error(f"Error sending record to DLQ: {e}")
 
 def get_vaccine_type(patientsk) -> str:

--- a/delta_backend/src/delta.py
+++ b/delta_backend/src/delta.py
@@ -18,7 +18,19 @@ logger = logging.getLogger()
 logger.setLevel("INFO")
 firehose_logger = FirehoseLogger()
 sqs_client = boto3.client("sqs")
+initialized = False
 
+def init():
+    """
+    Initialize the lambda. This runs on cold start.
+    """
+    global delta_table, initialized 
+    if not initialized:        
+        logger.info("Initializing Delta Handler")
+        dynamodb = boto3.resource("dynamodb", region_name="eu-west-2")
+        delta_table = dynamodb.Table(delta_table_name)
+        initialized = True
+    return delta_table
 
 def send_message(record, queue_url):
     # Create a message
@@ -30,129 +42,134 @@ def send_message(record, queue_url):
     except ClientError as e:
         logger.error(f"Error sending record to DLQ: {e}")
 
-
 def get_vaccine_type(patientsk) -> str:
     parsed = [str.strip(str.lower(s)) for s in patientsk.split("#")]
     return parsed[0]
 
+def send_firehose(log_data):
+    try:
+        firehose_log = {"event": log_data}
+        firehose_logger.send_log(firehose_log)
+    except Exception as e:
+        logger.error(f"Error sending log to Firehose: {e}")
+
+def process_record(record, delta_table, log_data):
+    ret = True
+    try:
+        start = time.time()
+        operation_outcome = {}
+        error_records = []
+        response = str()
+        imms_id = str()
+        operation = str()
+        approximate_creation_time = datetime.utcfromtimestamp(record["dynamodb"]["ApproximateCreationDateTime"])
+        expiry_time = approximate_creation_time + timedelta(days=30)
+        expiry_time_epoch = int(expiry_time.timestamp())
+
+        if record["eventName"] != EventName.DELETE_PHYSICAL:
+            new_image = record["dynamodb"]["NewImage"]
+            imms_id = new_image["PK"]["S"].split("#")[1]
+            vaccine_type = get_vaccine_type(new_image["PatientSK"]["S"])
+            supplier_system = new_image["SupplierSystem"]["S"]
+            if supplier_system not in ("DPSFULL", "DPSREDUCED"):
+                operation = new_image["Operation"]["S"]
+                action_flag = ActionFlag.CREATE if operation == Operation.CREATE else operation
+                resource_json = json.loads(new_image["Resource"]["S"])
+                FHIRConverter = Converter(resource_json, action_flag=action_flag)
+                flat_json = FHIRConverter.run_conversion()
+                error_records = FHIRConverter.get_error_records()
+                response = delta_table.put_item(
+                    Item={
+                        "PK": str(uuid.uuid4()),
+                        "ImmsID": imms_id,
+                        "Operation": operation,
+                        "VaccineType": vaccine_type,
+                        "SupplierSystem": supplier_system,
+                        "DateTimeStamp": approximate_creation_time.isoformat(),
+                        "Source": delta_source,
+                        "Imms": flat_json,
+                        "ExpiresAt": expiry_time_epoch,
+                    }
+                )
+            else:
+                operation_outcome["statusCode"] = "200"
+                operation_outcome["statusDesc"] = "Record from DPS skipped"
+                log_data["operation_outcome"] = operation_outcome
+                logger.info(f"Record from DPS skipped for {imms_id}")
+                return True, log_data
+        else:
+            operation = Operation.DELETE_PHYSICAL
+            new_image = record["dynamodb"]["Keys"]
+            logger.info(f"Record to delta:{new_image}")
+            imms_id = new_image["PK"]["S"].split("#")[1]
+            response = delta_table.put_item(
+                Item={
+                    "PK": str(uuid.uuid4()),
+                    "ImmsID": imms_id,
+                    "Operation": operation,
+                    "VaccineType": "default",
+                    "SupplierSystem": "default",
+                    "DateTimeStamp": approximate_creation_time.isoformat(),
+                    "Source": delta_source,
+                    "Imms": "",
+                    "ExpiresAt": expiry_time_epoch,
+                }
+            )
+        end = time.time()
+        log_data["time_taken"] = f"{round(end - start, 5)}s"
+        operation_outcome = {"record": imms_id, "operation_type": operation}
+        if response["ResponseMetadata"]["HTTPStatusCode"] == 200:
+            if error_records:
+                log = f"Partial success: successfully synced into delta, but issues found within record {imms_id}"
+                operation_outcome["statusCode"] = "207"
+                operation_outcome["statusDesc"] = (
+                    f"Partial success: successfully synced into delta, but issues found within record {json.dumps(error_records)}"
+                )
+            else:
+                log = f"Record Successfully created for {imms_id}"
+                operation_outcome["statusCode"] = "200"
+                operation_outcome["statusDesc"] = "Successfully synched into delta"
+            logger.info(log)
+        else:
+            log = f"Record NOT created for {imms_id}"
+            operation_outcome["statusCode"] = "500"
+            operation_outcome["statusDesc"] = "Exception"
+            logger.warning(log)
+            ret = False
+    except Exception as e:
+        operation_outcome["statusCode"] = "500"
+        operation_outcome["statusDesc"] = "Exception"
+        logger.exception(f"Error processing record: {e}")
+        ret = False
+    
+    log_data["operation_outcome"] = operation_outcome
+    return ret, log_data
 
 def handler(event, context):
     ret = True
     logger.info("Starting Delta Handler")
     log_data = dict()
-    firehose_log = dict()
     operation_outcome = dict()
     log_data["function_name"] = "delta_sync"
-    intrusion_check = True
     try:
-        dynamodb = boto3.resource("dynamodb", region_name="eu-west-2")
-        delta_table = dynamodb.Table(delta_table_name)
-
-        # Converting ApproximateCreationDateTime directly to string will give Unix timestamp
-        # I am converting it to isofformat for filtering purpose. This can be changed accordingly
+        delta_table = init()
 
         for record in event["Records"]:
-            start = time.time()
             log_data["date_time"] = str(datetime.now())
-            intrusion_check = False
-            approximate_creation_time = datetime.utcfromtimestamp(record["dynamodb"]["ApproximateCreationDateTime"])
-            expiry_time = approximate_creation_time + timedelta(days=30)
-            expiry_time_epoch = int(expiry_time.timestamp())
-            error_records = []
-            response = str()
-            imms_id = str()
-            operation = str()
-            if record["eventName"] != EventName.DELETE_PHYSICAL:
-                new_image = record["dynamodb"]["NewImage"]
-                imms_id = new_image["PK"]["S"].split("#")[1]
-                vaccine_type = get_vaccine_type(new_image["PatientSK"]["S"])
-                supplier_system = new_image["SupplierSystem"]["S"]
-                if supplier_system not in ("DPSFULL", "DPSREDUCED"):
-                    operation = new_image["Operation"]["S"]
-                    action_flag = ActionFlag.CREATE if operation == Operation.CREATE else operation
-                    resource_json = json.loads(new_image["Resource"]["S"])
-                    FHIRConverter = Converter(resource_json, action_flag = action_flag)
-                    flat_json = FHIRConverter.run_conversion()  # Get the flat JSON
-                    error_records = FHIRConverter.get_error_records()
-                    response = delta_table.put_item(
-                        Item={
-                            "PK": str(uuid.uuid4()),
-                            "ImmsID": imms_id,
-                            "Operation": operation,
-                            "VaccineType": vaccine_type,
-                            "SupplierSystem": supplier_system,
-                            "DateTimeStamp": approximate_creation_time.isoformat(),
-                            "Source": delta_source,
-                            "Imms": flat_json,
-                            "ExpiresAt": expiry_time_epoch,
-                        }
-                    )
-                else:
-                    operation_outcome["statusCode"] = "200"
-                    operation_outcome["statusDesc"] = "Record from DPS skipped"
-                    log_data["operation_outcome"] = operation_outcome
-                    firehose_log["event"] = log_data
-                    firehose_logger.send_log(firehose_log)
-                    logger.info(f"Record from DPS skipped for {imms_id}")
-                    continue
-            else:
-                operation = Operation.DELETE_PHYSICAL
-                new_image = record["dynamodb"]["Keys"]
-                logger.info(f"Record to delta:{new_image}")
-                imms_id = new_image["PK"]["S"].split("#")[1]
-                response = delta_table.put_item(
-                    Item={
-                        "PK": str(uuid.uuid4()),
-                        "ImmsID": imms_id,
-                        "Operation": Operation.DELETE_PHYSICAL,
-                        "VaccineType": "default",
-                        "SupplierSystem": "default",
-                        "DateTimeStamp": approximate_creation_time.isoformat(),
-                        "Source": delta_source,
-                        "Imms": "",
-                        "ExpiresAt": expiry_time_epoch,
-                    }
-                )
-            end = time.time()
-            log_data["time_taken"] = f"{round(end - start, 5)}s"
-            operation_outcome = {"record": imms_id, "operation_type": operation}
-            if response["ResponseMetadata"]["HTTPStatusCode"] == 200:
-                if error_records:
-                    log = f"Partial success: successfully synced into delta, but issues found within record {imms_id}"
-                    operation_outcome["statusCode"] = "207"
-                    operation_outcome["statusDesc"] = (
-                        f"Partial success: successfully synced into delta, but issues found within record {json.dumps(error_records)}"
-                    )
-                else:
-                    log = f"Record Successfully created for {imms_id}"
-                    operation_outcome["statusCode"] = "200"
-                    operation_outcome["statusDesc"] = "Successfully synched into delta"
-                log_data["operation_outcome"] = operation_outcome
-                firehose_log["event"] = log_data
-                firehose_logger.send_log(firehose_log)
-                logger.info(log)
-            else:
-                log = f"Record NOT created for {imms_id}"
-                operation_outcome["statusCode"] = "500"
-                operation_outcome["statusDesc"] = "Exception"
-                log_data["operation_outcome"] = operation_outcome
-                firehose_log["event"] = log_data
-                firehose_logger.send_log(firehose_log)
-                logger.info(log)
+            result, log_data = process_record(record, delta_table, log_data)
+            send_firehose(log_data)
+            if not result:
                 ret = False
 
     except Exception as e:
-        operation_outcome["statusCode"] = "500"
-        operation_outcome["statusDesc"] = "Exception"
-        if intrusion_check:
-            operation_outcome["diagnostics"] = "Incorrect invocation of Lambda"
-            logger.exception("Incorrect invocation of Lambda")
-        else:
-            operation_outcome["diagnostics"] = f"Delta Lambda failure: {e}"
-            logger.exception(f"Delta Lambda failure: {e}")
-            send_message(event, failure_queue_url)  # Send failed records to DLQ
-        log_data["operation_outcome"] = operation_outcome
-        firehose_log["event"] = log_data
-        firehose_logger.send_log(firehose_log)
         ret = False
+        operation_outcome = {
+            "statusCode": "500",
+            "statusDesc": "Exception",
+            "diagnostics": f"Delta Lambda failure: Incorrect invocation of Lambda"
+        }
+        logger.exception(operation_outcome["diagnostics"])
+        send_message(event, sqs_client)  # Send failed records to DLQ
+        log_data["operation_outcome"] = operation_outcome
+        send_firehose(log_data)
     return ret

--- a/delta_backend/src/delta.py
+++ b/delta_backend/src/delta.py
@@ -17,13 +17,12 @@ logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel("INFO")
 firehose_logger = FirehoseLogger()
+sqs_client = boto3.client("sqs")
 
 
 def send_message(record):
     # Create a message
     message_body = record
-    # Use boto3 to interact with SQS
-    sqs_client = boto3.client("sqs")
     try:
         # Send the record to the queue
         sqs_client.send_message(QueueUrl=failure_queue_url, MessageBody=json.dumps(message_body))

--- a/delta_backend/src/delta.py
+++ b/delta_backend/src/delta.py
@@ -18,7 +18,6 @@ logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel("INFO")
 firehose_logger = FirehoseLogger()
-initialized = False
 
 delta_table = None
 def get_delta_table():

--- a/delta_backend/tests/test_delta.py
+++ b/delta_backend/tests/test_delta.py
@@ -607,7 +607,8 @@ class TestGetSqsClient(unittest.TestCase):
 
         client = delta.get_sqs_client()
         self.assertIs(client, mock_client)
-        self.mock_sqs_client.assert_not_called()  # Should not re-initialize
+        # Should not re-initialize
+        self.mock_sqs_client.assert_not_called()
 
     def test_returns_none_on_exception(self):
         self.mock_sqs_client.side_effect = Exception("fail")
@@ -620,13 +621,11 @@ import delta
 
 class TestSendMessage(unittest.TestCase):
     def setUp(self):
-        # Patch get_sqs_client to return a mock SQS client
         self.get_sqs_client_patcher = patch("delta.get_sqs_client")
         self.mock_get_sqs_client = self.get_sqs_client_patcher.start()
         self.mock_sqs_client = MagicMock()
         self.mock_get_sqs_client.return_value = self.mock_sqs_client
 
-        # Patch logger.info and logger.error
         self.logger_info_patcher = patch("logging.Logger.info")
         self.mock_logger_info = self.logger_info_patcher.start()
         self.logger_error_patcher = patch("logging.Logger.error")
@@ -638,7 +637,7 @@ class TestSendMessage(unittest.TestCase):
         self.logger_error_patcher.stop()
 
     def test_send_message_success(self):
-        record = {"foo": "bar"}
+        record = {"a": "bbb"}
         self.mock_sqs_client.send_message.return_value = {"MessageId": "123"}
 
         delta.send_message(record)
@@ -648,7 +647,7 @@ class TestSendMessage(unittest.TestCase):
         self.mock_logger_error.assert_not_called()
 
     def test_send_message_client_error(self):
-        record = {"foo": "bar"}
+        record = {"a": "bbb"}
         self.mock_sqs_client.send_message.side_effect = Exception("SQS error")
 
         delta.send_message(record, "test-queue-url")

--- a/delta_backend/tests/test_delta.py
+++ b/delta_backend/tests/test_delta.py
@@ -62,13 +62,14 @@ class DeltaTestCase(unittest.TestCase):
         # Arrange
         self.mock_sqs_client.send_message.return_value = {"MessageId": "123"}
         record = {"key": "value"}
+        sqs_queue_url = "test-queue-url"
 
         # Act
-        send_message(record)
+        send_message(record, sqs_queue_url)
 
         # Assert
         self.mock_sqs_client.send_message.assert_called_once_with(
-            QueueUrl="some-queue", MessageBody=json.dumps(record)
+            QueueUrl=sqs_queue_url, MessageBody=json.dumps(record)
         )
 
     @patch("logging.Logger.error")
@@ -81,7 +82,7 @@ class DeltaTestCase(unittest.TestCase):
         self.mock_sqs_client.send_message.side_effect = ClientError(error_response, "SendMessage")
 
         # Act
-        send_message(record)
+        send_message(record, "test-queue-url")
 
         # Assert
         mock_logger_error.assert_called_once_with(

--- a/delta_backend/tests/test_delta.py
+++ b/delta_backend/tests/test_delta.py
@@ -189,10 +189,8 @@ class DeltaHandlerTestCase(unittest.TestCase):
         # Check logging and Firehose were called
         mock_logger_info.assert_called_with("Record from DPS skipped for 12345")
 
-    @patch("delta.logger.info")
     @patch("delta.Converter")
-    @patch("delta.boto3.resource")
-    def test_partial_success_with_errors(self, mock_dynamodb, mock_converter, mock_logger_info):
+    def test_partial_success_with_errors(self, mock_converter):
         mock_converter_instance = MagicMock()
         mock_converter_instance.run_conversion.return_value = {"ABC":"DEF"}
         mock_converter_instance.get_error_records.return_value = [{"error": "Invalid field"}]
@@ -208,7 +206,7 @@ class DeltaHandlerTestCase(unittest.TestCase):
 
         self.assertTrue(response)
         # Check logging and Firehose were called
-        mock_logger_info.assert_called()
+        self.mock_logger_info.assert_called()
         self.assertEqual(self.mock_firehose_logger.send_log.call_count, 1)
         self.mock_firehose_logger.send_log.assert_called_once()
 

--- a/delta_backend/tests/test_delta.py
+++ b/delta_backend/tests/test_delta.py
@@ -49,7 +49,6 @@ class DeltaHandlerTestCase(unittest.TestCase):
         self.mock_firehose_logger.stop()
         self.sqs_client_patcher.stop()
         self.delta_table_patcher.stop()
-        # self.process_record_patcher.stop()
 
     def test_send_message_success(self):
         # Arrange

--- a/delta_backend/tests/test_delta.py
+++ b/delta_backend/tests/test_delta.py
@@ -180,9 +180,8 @@ class DeltaHandlerTestCase(unittest.TestCase):
     @patch("delta.logger.info") 
     def test_dps_record_skipped(self, mock_logger_info):
         event = ValuesForTests.get_event(supplier="DPSFULL")
-        context = {}
 
-        response = handler(event, context)
+        response = handler(event, None)
 
         self.assertTrue(response)
 
@@ -200,9 +199,8 @@ class DeltaHandlerTestCase(unittest.TestCase):
         self.mock_delta_table.put_item.return_value = success_response
 
         event = ValuesForTests.get_event()
-        context = {}
 
-        response = handler(event, context)
+        response = handler(event, None)
 
         self.assertTrue(response)
         # Check logging and Firehose were called


### PR DESCRIPTION
## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

https://nhsd-jira.digital.nhs.uk/browse/VED-292
Changes:

- Refactor to process individual records in a function
- Initialise SQS & DynamoDb once only
- unit tests, including to check processing continues if an error occurs
- protect sqs initialisation from unhandled exception
- wrap firehose with exception mgt
- prevent unhandled exception in handler exception catch
- Skipped records are logged to firehose, but not saved


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
