### PR TITLE
VED-171: Fix inconsistent teardown pipeline triggering.

### DIFF
--- a/.github/workflows/continuous-disintegration.yml
+++ b/.github/workflows/continuous-disintegration.yml
@@ -1,7 +1,7 @@
 name: Teardown
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:

--- a/azure/azure-pr-teardown-pipeline.yml
+++ b/azure/azure-pr-teardown-pipeline.yml
@@ -10,11 +10,6 @@ resources:
       name: NHSDigital/api-management-utils
       ref: refs/heads/edge
       endpoint: NHSDigital
-    - repository: immunisation-fhir-api
-      type: github
-      name: NHSDigital/immunisation-fhir-api
-      ref: master
-      endpoint: NHSDigital
 
 variables:
   - template: project.yml
@@ -27,7 +22,7 @@ jobs:
       name: 'AWS-ECS'
       vmImage: 'ubuntu-latest'
     steps:
-      - checkout: immunisation-fhir-api
+      - checkout: self
 
       - bash: |
           echo $(action_pr_number)


### PR DESCRIPTION
## Summary
* Routine Change
* :robot: Operational or Infrastructure Change

Change the teardown pipeline trigger to `pull_request_target`. This should fix an issue we're seeing where the pipeline doesn't always run on PR close. This trigger runs the workflow even if there are conflicts between the merge and base commits, unlike the `pull_request` trigger. There may also be differences with how the workflow runs are queued. See https://github.com/orgs/community/discussions/26657 where this fix is suggested.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
