### PR TITLE
VED-245: Prevent stuck batches if the input file is missing.

### DIFF
--- a/recordprocessor/src/utils_for_recordprocessor.py
+++ b/recordprocessor/src/utils_for_recordprocessor.py
@@ -16,7 +16,7 @@ def get_environment() -> str:
     return _env if _env in ["internal-dev", "int", "ref", "sandbox", "prod"] else "internal-dev"
 
 
-def get_csv_content_dict_reader(file_key: str) -> DictReader:
+def get_csv_content_dict_reader(file_key: str) -> (DictReader, str):
     """Returns the requested file contents from the source bucket in the form of a DictReader"""
     response = s3_client.get_object(Bucket=os.getenv("SOURCE_BUCKET_NAME"), Key=file_key)
     csv_data = response["Body"].read().decode("utf-8")


### PR DESCRIPTION
## Summary
* Routine Change


Fix an issue where a batch can become stuck in a `Processing` state if an error (`NoSuchKey`) occurs while handling another error, resulting in the record processor bombing out before updating the audit table.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
