### PR TITLE
Update disease mapping and supplier permissions.

### DIFF
--- a/config/common/disease_mapping.json
+++ b/config/common/disease_mapping.json
@@ -1,10 +1,18 @@
 [
   {
-    "vacc_type": "COVID19",
+    "vacc_type": "3IN1",
     "diseases": [
       {
-        "code": "840539006",
-        "term": "Disease caused by severe acute respiratory syndrome coronavirus 2"
+        "code": "398102009",
+        "term": "Acute poliomyelitis"
+      },
+      {
+        "code": "397430003",
+        "term": "Diphtheria caused by Corynebacterium diphtheriae"
+      },
+      {
+        "code": "76902006",
+        "term": "Tetanus (disorder)"
       }
     ]
   },
@@ -27,6 +35,15 @@
     ]
   },
   {
+    "vacc_type": "MENACWY",
+    "diseases": [
+      {
+        "code": "23511006",
+        "term": "Meningococcal infectious disease"
+      }
+    ]
+  },
+  {
     "vacc_type": "MMR",
     "diseases": [
       {
@@ -44,85 +61,11 @@
     ]
   },
   {
-    "vacc_type": "MMRV",
-    "diseases": [
-      {
-        "code": "14189004",
-        "term": "Measles (disorder)"
-      },
-      {
-        "code": "36989005",
-        "term": "Mumps (disorder)"
-      },
-      {
-        "code": "36653000",
-        "term": "Rubella (disorder)"
-      },
-      {
-        "code": "38907003",
-        "term": "Varicella (disorder)"
-      }
-    ]
-  },
-  {
     "vacc_type": "RSV",
     "diseases": [
       {
         "code": "55735004",
         "term": "Respiratory syncytial virus infection (disorder)"
-      }
-    ]
-  },
-  {
-    "vacc_type": "PERTUSSIS",
-    "diseases": [
-      {
-        "code": "27836007",
-        "term": "Pertussis (disorder)"
-      }
-    ]
-  },
-  {
-    "vacc_type": "SHINGLES",
-    "diseases": [
-      {
-        "code": "4740000",
-        "term": "Herpes zoster"
-      }
-    ]
-  },
-  {
-    "vacc_type": "PCV13",
-    "diseases": [
-      {
-        "code": "16814004",
-        "term": "Pneumococcal infectious disease"
-      }
-    ]
-  },
-  {
-    "vacc_type": "3in1",
-    "diseases": [
-      {
-        "code": "398102009",
-        "term": "Acute poliomyelitis"
-      },
-      {
-        "code": "397430003",
-        "term": "Diphtheria caused by Corynebacterium diphtheriae"
-      },
-      {
-        "code": "76902006",
-        "term": "Tetanus (disorder)"
-      }
-    ]
-  },
-  {
-    "vacc_type": "MENACWY",
-    "diseases": [
-      {
-        "code": "23511006",
-        "term": "Meningococcal infectious disease"
       }
     ]
   }

--- a/config/dev/permissions_config.json
+++ b/config/dev/permissions_config.json
@@ -28,32 +28,10 @@
     ]
   },
   {
-    "supplier": "EMIS",
-    "permissions": [
-      "RSV.U"
-    ]
-  },
-  {
-    "supplier": "PINNACLE",
-    "permissions": []
-  },
-  {
     "supplier": "SONAR",
     "permissions": [
       "FLU.CD"
     ]
-  },
-  {
-    "supplier": "TPP",
-    "permissions": []
-  },
-  {
-    "supplier": "AGEM-NIVS",
-    "permissions": []
-  },
-  {
-    "supplier": "NIMS",
-    "permissions": []
   },
   {
     "supplier": "EVA",
@@ -64,22 +42,46 @@
   {
     "supplier": "RAVS",
     "permissions": [
-      "RSV.CRUDS"
+      "RSV.CRUDS",
+      "MMR.CRUDS"
     ]
   },
   {
     "supplier": "AGEM-RAVS-Integration",
     "permissions": [
-      "RSV.CRUDS"
+      "RSV.CRUDS",
+      "MMR.CRUDS"
     ]
   },
   {
-    "supplier": "MEDICAL_DIRECTOR",
-    "permissions": []
+    "supplier": "EMIS",
+    "permissions": [
+      "RSV.CRUDS",
+      "MMR.CRUDS",
+      "HPV.CRUDS",
+      "3IN1.CRUDS",
+      "MENACWY.CRUDS"
+    ]
   },
   {
-    "supplier": "COVID19_VACCINE_RESOLUTION_SERVICEDESK",
-    "permissions": []
+    "supplier": "TPP",
+    "permissions": [
+      "RSV.CRUDS",
+      "MMR.CRUDS",
+      "HPV.CRUDS",
+      "3IN1.CRUDS",
+      "MENACWY.CRUDS"
+    ]
+  },
+  {
+    "supplier": "MEDICUS",
+    "permissions": [
+      "RSV.CRUDS",
+      "MMR.CRUDS",
+      "HPV.CRUDS",
+      "3IN1.CRUDS",
+      "MENACWY.CRUDS"
+    ]
   },
   {
     "supplier": "Test_App",

--- a/config/preprod/permissions_config.json
+++ b/config/preprod/permissions_config.json
@@ -30,7 +30,45 @@
   {
     "supplier": "RAVS",
     "permissions": [
-      "RSV.CRUDS"
+      "RSV.CRUDS",
+      "MMR.CRUDS"
+    ]
+  },
+  {
+    "supplier": "AGEM-RAVS-Integration",
+    "permissions": [
+      "RSV.CRUDS",
+      "MMR.CRUDS"
+    ]
+  },
+  {
+    "supplier": "EMIS",
+    "permissions": [
+      "RSV.CRUDS",
+      "MMR.CRUDS",
+      "HPV.CRUDS",
+      "3IN1.CRUDS",
+      "MENACWY.CRUDS"
+    ]
+  },
+  {
+    "supplier": "TPP",
+    "permissions": [
+      "RSV.CRUDS",
+      "MMR.CRUDS",
+      "HPV.CRUDS",
+      "3IN1.CRUDS",
+      "MENACWY.CRUDS"
+    ]
+  },
+  {
+    "supplier": "MEDICUS",
+    "permissions": [
+      "RSV.CRUDS",
+      "MMR.CRUDS",
+      "HPV.CRUDS",
+      "3IN1.CRUDS",
+      "MENACWY.CRUDS"
     ]
   },
   {

--- a/filenameprocessor/src/constants.py
+++ b/filenameprocessor/src/constants.py
@@ -72,6 +72,7 @@ class Constants:
         "YA7": "SCOTLAND_DA",
         "N2N9I": "COVID19_VACCINE_RESOLUTION_SERVICEDESK",
         "YGJ": "EMIS",
+        "YGMYW": "MEDICUS",
         "DPSREDUCED": "DPSREDUCED",
         "DPSFULL": "DPSFULL",
     }


### PR DESCRIPTION
## Summary
* Routine Change


Changes as requested by Ben:
* Enable RAVS for MMR in non-prod envs.
* Enable Optum, TPP and Medicus in non-prod envs for assurance.
* Remove non-essential entries from disease mapping.


Also removed some empty permissions entries and sorted the disease mapping file.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
