### PR TITLE
Fixed JIRA PR linking and added helpers to backend Makefile

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -5,23 +5,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check ticket name conforms to requirements
-        run: echo ${{ github.event.pull_request.head.ref }} | grep -i -E -q "(amb-[0-9]+)|(ambspii-[0-9]+)|(adz-[0-9]+)|(amb-[0-9]+)|(dependabot\/)"
+        run: echo ${{ github.event.pull_request.head.ref }} | grep -i -E -q "(amb-[0-9]+)|(ambspii-[0-9]+)|(adz-[0-9]+)|(ved-[0-9]+)|(dependabot\/)"
         continue-on-error: true
 
       - name: Grab ticket name
-        if: contains(github.event.pull_request.head.ref, 'amb-') || contains(github.event.pull_request.head.ref, 'AMB-') || contains(github.event.pull_request.head.ref, 'ambspii-') || contains(github.event.pull_request.head.ref, 'AMBSPII-') || contains(github.event.pull_request.head.ref, 'adz-') || contains(github.event.pull_request.head.ref, 'ADZ-') || contains(github.event.pull_request.head.ref, 'amb-') || contains(github.event.pull_request.head.ref, 'AMB-')
-        run: echo ::set-env name=TICKET_NAME::$(echo ${{ github.event.pull_request.head.ref }} | grep -i -o '\(amb-[0-9]\+\)\|\(ambspii-[0-9]\+\)\|\(adz-[0-9]\+\)|\(amb-[0-9]\+\)' | tr '[:lower:]' '[:upper:]')
+        if: contains(github.event.pull_request.head.ref, 'amb-') || contains(github.event.pull_request.head.ref, 'AMB-') || contains(github.event.pull_request.head.ref, 'ambspii-') || contains(github.event.pull_request.head.ref, 'AMBSPII-') || contains(github.event.pull_request.head.ref, 'adz-') || contains(github.event.pull_request.head.ref, 'ADZ-') || contains(github.event.pull_request.head.ref, 'ved-') || contains(github.event.pull_request.head.ref, 'VED-')
+        run: echo ::set-env name=TICKET_NAME::$(echo ${{ github.event.pull_request.head.ref }} | grep -i -o '\(amb-[0-9]\+\)\|\(ambspii-[0-9]\+\)\|\(adz-[0-9]\+\)|\(ved-[0-9]\+\)' | tr '[:lower:]' '[:upper:]')
         continue-on-error: true
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Comment on PR with link to JIRA ticket
-        if: contains(github.event.pull_request.head.ref, 'amb-') || contains(github.event.pull_request.head.ref, 'AMB-') || contains(github.event.pull_request.head.ref, 'ambspii-') || contains(github.event.pull_request.head.ref, 'AMBSPII-') || contains(github.event.pull_request.head.ref, 'adz-') || contains(github.event.pull_request.head.ref, 'ADZ-') || contains(github.event.pull_request.head.ref, 'amb-') || contains(github.event.pull_request.head.ref, 'AMB-')
+        if: contains(github.event.pull_request.head.ref, 'amb-') || contains(github.event.pull_request.head.ref, 'AMB-') || contains(github.event.pull_request.head.ref, 'ambspii-') || contains(github.event.pull_request.head.ref, 'AMBSPII-') || contains(github.event.pull_request.head.ref, 'adz-') || contains(github.event.pull_request.head.ref, 'ADZ-') || contains(github.event.pull_request.head.ref, 'ved-') || contains(github.event.pull_request.head.ref, 'VED-')
         continue-on-error: true
         uses: unsplash/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           msg: |
-            This branch is work on a ticket in the NHS Digital AMB JIRA Project. Here's a handy link to the ticket:
+            This branch is working on a ticket in the NHS England VED JIRA Project. Here's a handy link to the ticket:
             # [${{ env.TICKET_NAME }}](https://nhsd-jira.digital.nhs.uk/browse/${{ env.TICKET_NAME}})

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,5 +1,7 @@
 name: PR Quality Check
-on: pull_request
+on:
+  pull_request:
+    types: [opened]
 jobs:
   link-ticket:
     runs-on: ubuntu-latest

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -8,4 +8,13 @@ package: build
 test:
 	@PYTHONPATH=src:tests python -m unittest
 
+coverage-run:
+	@PYTHONPATH=src:tests coverage run -m unittest discover -v
+
+coverage-report:
+	coverage report -m 
+
+coverage-html:
+	coverage html
+
 .PHONY: build package test


### PR DESCRIPTION
## Summary
* Routine Change

(I still do not have access to the NHS GH Organisation so created this PR from a forked repo).

**Changes:**
- Removed duplicated references to the `amb` JIRA project.
- Added checks for the `ved` JIRA project, which seems to be the one that this team is using. **Please could** someone advise if any of the others can be removed and if there is anything we additionally need.
- Modified the `pr-lint` workflow to only run when the PR is opened (i.e. once). Previously it was being run on every synchronize event, which seems unecessary.
- Added a couple of helpful functions to the `backend` Makefile. I was working with Rob and after running the tests we also wanted to view the coverage.

* Note: I have left the pr-lint workflow mostly unchanged, such that if it fails for any reason it will `continue-on-error` and not block. This hopefully will minimise noise, but the benefit of the change is that we should now start to have a linked JIRA ticket on the PR.

## Reviews Required
* [x] Dev

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
