### PR TITLE
VED-734 Adjust the batch size for the ack lambda

### DIFF
--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Install Poetry
         run: |
-          curl -sSL https://install.python-poetry.org | python3 - --version 2.1.2
+          curl -sSL https://install.python-poetry.org | python3 - --version 2.1.4
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           poetry --version
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-poetry 2.1.2
+poetry 2.1.4
 nodejs 23.11.0
 python 3.11.12

--- a/terraform/ack_lambda.tf
+++ b/terraform/ack_lambda.tf
@@ -231,6 +231,6 @@ resource "aws_lambda_function" "ack_processor_lambda" {
 resource "aws_lambda_event_source_mapping" "sqs_to_lambda" {
   event_source_arn = aws_sqs_queue.fifo_queue.arn
   function_name    = aws_lambda_function.ack_processor_lambda.arn
-  batch_size       = 10
+  batch_size       = 1 # VED-734 - forwarder lambda already sends a list of up to 100 messages in the body
   enabled          = true
 }


### PR DESCRIPTION
## Summary
* Routine Change

https://github.com/NHSDigital/immunisation-fhir-api/pull/758 Had expected would happily resolve any outstanding issues with the batch processor. Under initial tests this was fine. However, when testing 8 files each with over 1000 rows there were a couple of instances where the ack backend lambda received multiple records relating to different parent CSVs.

Note: this should not be happening in SQS FIFO. The parent CSV + timestamp is used as the message group ID so each record in a batch should all relate to the same parent CSV.

However, we observed that this was clearly not the case.

https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fimms-int-ack-lambda/log-events/2025$252F08$252F22$252F$255B$2524LATEST$255D6ef94677314846ff8e254f5ed6e3b730$3Fstart$3D1755863844222$26refEventId$3D39157072195537363057061832143017231114681348590429012592

Invocation 44e0c7da-d837-502c-92a9-a6f88568505c (which was quite long btw lasting 8 seconds) saw events from 2 files - 1 relating to 3 in 1 and 1 relating to Menacwy.

Therefore concluded the only reliable fix is to restrict the batch size to 1. This ensures that each time the ack lambda picks up messages it will **only** be dealing with events to do with the same CSV file and it will update the ack file accordingly.

Tried a quick test by manually changing the batch size in INT and it worked perfectly.

## Reviews Required
* [x] Dev

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
