### PR TITLE
VED-754 Handle non utf 8 encoded csv (bugfix)

### DIFF
--- a/recordprocessor/src/constants.py
+++ b/recordprocessor/src/constants.py
@@ -48,6 +48,9 @@ EXPECTED_CSV_HEADERS = [
 ]
 
 
+INTERNAL_SUPPLIER_NAMES = {"DPSFULL", "DPSREDUCED"}
+
+
 class FileStatus:
     """File status constants"""
 

--- a/recordprocessor/src/file_level_validation.py
+++ b/recordprocessor/src/file_level_validation.py
@@ -78,7 +78,7 @@ def file_level_validation(incoming_message_body: dict) -> dict:
         created_at_formatted_string = incoming_message_body.get("created_at_formatted_string")
 
         # Fetch the data
-        csv_reader = get_csv_content_dict_reader(file_key)
+        csv_reader = get_csv_content_dict_reader(file_key, supplier)
 
         validate_content_headers(csv_reader)
 

--- a/recordprocessor/tests/test_utils_for_recordprocessor.py
+++ b/recordprocessor/tests/test_utils_for_recordprocessor.py
@@ -48,7 +48,7 @@ class TestUtilsForRecordprocessor(unittest.TestCase):
         """Tests that get_csv_content_dict_reader returns the correct csv data"""
         self.upload_source_file(test_file.file_key, ValidMockFileContent.with_new_and_update)
         expected_output = csv.DictReader(StringIO(ValidMockFileContent.with_new_and_update), delimiter="|")
-        result = get_csv_content_dict_reader(test_file.file_key)
+        result = get_csv_content_dict_reader(test_file.file_key, "RAVS")
         self.assertEqual(list(result), list(expected_output))
 
     def test_get_environment(self):

--- a/recordprocessor/tests/utils_for_recordprocessor_tests/values_for_recordprocessor_tests.py
+++ b/recordprocessor/tests/utils_for_recordprocessor_tests/values_for_recordprocessor_tests.py
@@ -112,6 +112,17 @@ class MockFileRows:
         '"J82068"|"https://fhir.nhs.uk/Id/ods-organization-code"'
     )
 
+    NEW_DPS_RECORD = (
+        '9674963871|"SABINA"|"GREIR"|"20190131"|"2"|"GU14 6TU"|"20240610T183325"|"J82067"|'
+        '"https://fhir.nhs.uk/Id/ods-organization-code"|"DPS_ID_1234"|"DPS_SYSTEM"|'
+        '"new"|"Ellena"|"O\'Reilly"|"20240101"|"TRUE"|'
+        '"1303503001"|"Administration of vaccine product containing only Human orthopneumovirus antigen (procedure)"|'
+        '1|"42605811000001109"|"Abrysvo vaccine powder and solvent for solution for injection 0.5ml vials (Pfizer Ltd) '
+        '(product)"|"Pfizer"|"RSVTEST"|"20241231"|"368208006"|"Left upper arm structure (body structure)"|'
+        '"78421000"|"Intramuscular route (qualifier value)"|"0.5"|"258773002"|"Milliliter (qualifier value)"|"Test"|'
+        '"J82067"|"https://fhir.nhs.uk/Id/ods-organization-code"'
+    )
+
     # For test case VED-754 - windows-1252 encoding issues only surfaces with characters outside of 0-127 ASCII
     NEW_WITH_SPECIAL_CHARACTERS = (
         '9674963871|"SABINA"|"GRÉIR"|"20190131"|"2"|"GU14 6TU"|"20240610T183325"|"J82067"|'
@@ -131,6 +142,7 @@ class ValidMockFileContent:
     headers = MockFileRows.HEADERS
     with_new = headers + "\n" + MockFileRows.NEW
     with_new_special_char = headers + "\n" + MockFileRows.NEW_WITH_SPECIAL_CHARACTERS
+    with_new_dps_record = headers + "\n" + MockFileRows.NEW_DPS_RECORD
     with_update = headers + "\n" + MockFileRows.UPDATE
     with_delete = headers + "\n" + MockFileRows.DELETE
     with_update_and_delete = headers + "\n" + MockFileRows.UPDATE + "\n" + MockFileRows.DELETE
@@ -210,6 +222,7 @@ class MockFileDetails:
     rsv_emis = FileDetails("RSV", "EMIS", "8HK48")
     flu_emis = FileDetails("FLU", "EMIS", "YGM41")
     ravs_flu = FileDetails("FLU", "RSV", "X26")
+    dps_flu = FileDetails("FLU", "DPSFULL", "DPSFULL")
 
 
 class UnorderedFieldDictionaries:


### PR DESCRIPTION
## Summary
* Bugfix/handling for specific supplier settings

See https://nhsd-jira.digital.nhs.uk/browse/VED-754 for the investigation and root cause. Essentially, until we update the specification to stipulate that we expect utf-8 encoding and suppliers come into line, it is fair and reasonable to put in temporary handling.

We would want to get rid of this as soon as we can, and reject files that do not conform to spec.

Note: this only occurs in a slim minority of cases, as the differences in encoding only surfaces for non-ASCII characters, which appear quite rarely within the batch extracts.

## Reviews Required
* [ ] Dev


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
