### PR TITLE
VED-769 Reduce error noise and up empty batch file threshold

### DIFF
--- a/filenameprocessor/src/constants.py
+++ b/filenameprocessor/src/constants.py
@@ -30,7 +30,7 @@ ERROR_TYPE_TO_STATUS_CODE_MAP = {
 }
 
 # The size in bytes of an empty batch file containing only the headers row
-EMPTY_BATCH_FILE_SIZE_IN_BYTES = 615
+EMPTY_BATCH_FILE_SIZE_IN_BYTES = 700
 
 
 class FileStatus(StrEnum):

--- a/filenameprocessor/src/file_name_processor.py
+++ b/filenameprocessor/src/file_name_processor.py
@@ -100,7 +100,11 @@ def handle_record(record) -> dict:
         UnhandledSqsError,
         Exception,
     ) as error:
-        logger.error("Error processing file '%s': %s", file_key, str(error))
+        if isinstance(error, EmptyFileError):
+            # Avoid error log noise for accepted scenario in which supplier provides a batch file with no records
+            logger.warning("Error processing file '%s': %s", file_key, str(error))
+        else:
+            logger.error("Error processing file '%s': %s", file_key, str(error))
 
         queue_name = f"{supplier}_{vaccine_type}"
         file_status = get_file_status_for_error(error)

--- a/filenameprocessor/tests/test_lambda_handler.py
+++ b/filenameprocessor/tests/test_lambda_handler.py
@@ -229,6 +229,11 @@ class TestLambdaHandlerDataSource(TestCase):
         self.assertEqual(self.get_audit_table_items(), expected_table_items)
         self.assert_no_sqs_message()
         self.assert_ack_file_contents(file_details)
+        self.mock_logger.warning.assert_called_once_with(
+            "Error processing file '%s': %s",
+            "RSV_Vaccinations_v5_X8E5B_20000101T00000001.csv",
+            "Initial file validation failed: batch file was empty"
+        )
 
     def test_lambda_handler_non_root_file(self):
         """


### PR DESCRIPTION
## Summary
* Routine Change

- Only log a warning for empty files to reduce noise for ITOC, and our own alerting
- Up batch file empty size threshold to account for other file formats.

## Reviews Required
* [ ] Dev


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
