### PR TITLE
VED-000 NOJIRA bumped the MESH fetch message lambda memory

### DIFF
--- a/mesh_infra/main.tf
+++ b/mesh_infra/main.tf
@@ -24,7 +24,7 @@ provider "aws" {
 
 
 module "mesh" {
-  source = "git::https://github.com/nhsdigital/terraform-aws-mesh-client.git//module?ref=v2.1.5"
+  source = "git::https://github.com/nhsdigital/terraform-aws-mesh-client.git//module?ref=v2.1.6"
 
   name_prefix = "imms-${var.aws_environment}"
   account_id  = var.imms_account_id
@@ -32,7 +32,8 @@ module "mesh" {
   subnet_ids  = toset([])
   mailbox_ids = var.mesh_mailbox_ids
 
-  compress_threshold          = 1 * 1024 * 1024
-  get_message_max_concurrency = 10
-  handshake_schedule          = "rate(24 hours)"
+  compress_threshold               = 1 * 1024 * 1024
+  get_message_max_concurrency      = 10
+  handshake_schedule               = "rate(24 hours)"
+  fetch_message_lambda_memory_size = 512
 }


### PR DESCRIPTION
## Summary
* Routine Change

Issue spotted in prod. We had a really large file from a supplier. As of the newest version of the MESH AWS Client you can bump the memory for lambdas if you anticipate handling very large files.

## Reviews Required
* [x] Dev


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
