### PR TITLE
VED-714 (Addition) - Add info log and fix rare race condition

### DIFF
--- a/filenameprocessor/src/file_name_processor.py
+++ b/filenameprocessor/src/file_name_processor.py
@@ -70,11 +70,11 @@ def handle_record(record) -> dict:
         permissions = validate_vaccine_type_permissions(vaccine_type=vaccine_type, supplier=supplier)
 
         queue_name = f"{supplier}_{vaccine_type}"
-        make_and_send_sqs_message(
-            file_key, message_id, permissions, vaccine_type, supplier, created_at_formatted_string
-        )
         upsert_audit_table(
             message_id, file_key, created_at_formatted_string, expiry_timestamp, queue_name, FileStatus.QUEUED
+        )
+        make_and_send_sqs_message(
+            file_key, message_id, permissions, vaccine_type, supplier, created_at_formatted_string
         )
 
         logger.info("Lambda invocation successful for file '%s'", file_key)

--- a/filenameprocessor/tests/test_lambda_handler.py
+++ b/filenameprocessor/tests/test_lambda_handler.py
@@ -10,7 +10,6 @@ import fakeredis
 from boto3 import client as boto3_client
 from moto import mock_s3, mock_sqs, mock_firehose, mock_dynamodb
 
-from errors import UnhandledSqsError
 from tests.utils_for_tests.generic_setup_and_teardown import GenericSetUp, GenericTearDown
 from tests.utils_for_tests.utils_for_filenameprocessor_tests import (
     assert_audit_table_entry,
@@ -288,7 +287,7 @@ class TestLambdaHandlerDataSource(TestCase):
 
     def test_lambda_adds_event_to_audit_table_as_failed_when_unexpected_exception_is_caught(self):
         """
-        Tests that when an unexpected error occurs e.g. sending to SQS (maybe in case of bad deployment):
+        Tests that when an unexpected error occurs e.g. an unexpected exception when validating permissions:
         * The file is added to the audit table with a status of 'Failed' and the reason
         * The message is not sent to SQS
         * The failure inf_ack file is created
@@ -298,8 +297,8 @@ class TestLambdaHandlerDataSource(TestCase):
 
         with (  # noqa: E999
             patch("file_name_processor.uuid4", return_value=test_file_details.message_id),  # noqa: E999
-            patch("file_name_processor.make_and_send_sqs_message", side_effect=UnhandledSqsError(
-                "Some client error with SQS"
+            patch("file_name_processor.validate_vaccine_type_permissions", side_effect=Exception(
+                "Some unexpected exception"
             ))
         ):  # noqa: E999
             lambda_handler(self.make_event([self.make_record(test_file_details.file_key)]), None)
@@ -310,7 +309,7 @@ class TestLambdaHandlerDataSource(TestCase):
                 "filename": {"S": test_file_details.file_key},
                 "queue_name": {"S": "EMIS_FLU"},
                 "status": {"S": "Failed"},
-                "error_details": {"S": "Some client error with SQS"},
+                "error_details": {"S": "Some unexpected exception"},
                 "timestamp": {"S": test_file_details.created_at_formatted_string},
                 "expires_at": {"N": str(test_file_details.expires_at)},
             }


### PR DESCRIPTION
## Summary
* Routine Change

Spotted an issue in the non-prod alerting channel. Have undertaken a couple of changes to make supporting the new Lambda a bit easier in future.

1. Add an info log at the start of the invocation with the filename and the message ID for traceability.
2. Ensure the audit table entry is saved before sending to SQS.

It is hard to replicate the issue as it is intermittent and requires a fair bit of traffic. However, I have seen circumstances where this happens when we have a lot of Medicus messages coming in at once.

Essentially if the batch filter Lambda is running hot, it could be that the filename proc lambda sends a message to SQS and this is picked up before it actually writes the batch table entry. As DDB is eventually consistent, this means that it might fail to retrieve the entry.

I therefore made a minor change to ensure it is created before sending to SQS.

## Reviews Required
* [ ] Dev


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
