### PR TITLE
VED-814 Resolve sonarcloud warnings on S3 bucket ownership

### DIFF
--- a/mesh_processor/tests/test_converter.py
+++ b/mesh_processor/tests/test_converter.py
@@ -6,6 +6,8 @@ import boto3
 from botocore.exceptions import ClientError
 from moto import mock_aws
 
+MOCK_MOTO_ACCOUNT_ID = "123456789012"
+
 
 def invoke_lambda(file_key: str):
     # Local import so that globals can be mocked
@@ -26,7 +28,7 @@ def invoke_lambda(file_key: str):
 
 
 @mock_aws
-@patch.dict(os.environ, {"DESTINATION_BUCKET_NAME": "destination-bucket"})
+@patch.dict(os.environ, {"DESTINATION_BUCKET_NAME": "destination-bucket", "ACCOUNT_ID": MOCK_MOTO_ACCOUNT_ID})
 class TestLambdaHandler(TestCase):
     def setUp(self):
         s3 = boto3.client("s3", region_name="eu-west-2")

--- a/terraform/mesh_processor.tf
+++ b/terraform/mesh_processor.tf
@@ -217,6 +217,7 @@ resource "aws_lambda_function" "mesh_file_converter_lambda" {
 
   environment {
     variables = {
+      ACCOUNT_ID              = var.immunisation_account_id
       DESTINATION_BUCKET_NAME = aws_s3_bucket.batch_data_source_bucket.bucket
     }
   }


### PR DESCRIPTION
## Summary
* Routine Change

Resolves the outstanding security warnings we have in Sonarcloud that causes us to fail on `master`/overall coverage: https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&types=VULNERABILITY&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&inNewCodePeriod=true&sinceLeakPeriod=true&id=NHSDigital_immunisation-fhir-api

- Add expected bucket owner account to boto3 S3 calls
- Update tests to pass using the moto default account ID

## Reviews Required
* [ ] Dev


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
