### PR TITLE
added COVID CRUDS permissions for TPP, MEDICUS and EMIS in prod config

### DIFF
--- a/config/prod/permissions_config.json
+++ b/config/prod/permissions_config.json
@@ -44,6 +44,7 @@
     "supplier": "EMIS",
     "permissions": [
       "3IN1.CRUDS",
+      "COVID.CRUDS",
       "FLU.CRUDS",
       "HPV.CRUDS",
       "MENACWY.CRUDS",
@@ -60,6 +61,7 @@
     "supplier": "TPP",
     "permissions": [
       "3IN1.CRUDS",
+      "COVID.CRUDS",
       "FLU.CRUDS",
       "HPV.CRUDS",
       "MENACWY.CRUDS",
@@ -76,6 +78,7 @@
     "supplier": "MEDICUS",
     "permissions": [
       "3IN1.CRUDS",
+      "COVID.CRUDS",
       "FLU.CRUDS",
       "HPV.CRUDS",
       "MENACWY.CRUDS",


### PR DESCRIPTION
## Summary

- Routine Change

added COVID CRUDS permissions for TPP, MEDICUS and EMIS in prod config - approval received and added to tickets
