### PR TITLE
VED-1229: Remove 10 image limit from ECR Recordprocessor repo

### DIFF
--- a/infrastructure/account/recordprocessor_ecr_repo.tf
+++ b/infrastructure/account/recordprocessor_ecr_repo.tf
@@ -5,26 +5,3 @@ resource "aws_ecr_repository" "recordprocessor_repository" {
   image_tag_mutability = "IMMUTABLE"
   name                 = "imms-recordprocessor-repo"
 }
-
-resource "aws_ecr_lifecycle_policy" "recordprocessor_repository_lifecycle_policy" {
-  repository = aws_ecr_repository.recordprocessor_repository.name
-
-  policy = <<EOF
-{
-  "rules": [
-    {
-      "rulePriority": 1,
-      "description": "Keep last 10 images.",
-      "selection": {
-        "tagStatus": "any",
-        "countType": "imageCountMoreThan",
-        "countNumber": 10
-      },
-      "action": {
-        "type": "expire"
-      }
-    }
-  ]
-}
-EOF
-}


### PR DESCRIPTION
Remove deprecated ECR lifecycle policy from recordprocessor ECR repository configuration in Terraform.